### PR TITLE
build: bump to node 20 for build and runtime

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,10 +18,10 @@ jobs:
           ref: ${{ github.ref }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Cache pip repository
         uses: actions/cache@v4

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install node 18
+      - name: Install node 20
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - name: Install project modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Install node 18
+      - name: Install node 20
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - name: Configure git

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install node 18
+      - name: Install node 20
         uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
           cache: npm
 
       - name: Setup Python 3.10

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -22,10 +22,10 @@ jobs:
           node-version: '20'
           cache: npm
 
-      - name: Setup Python 3.10
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Cache pip repository
         uses: actions/cache@v4

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,8 @@
         "sinon-chai": "^3.7.0"
       },
       "engines": {
-        "node": ">= 18.0.0"
+        "node": ">= 20.0.0",
+        "npm": ">= 10.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "sinon-chai": "^3.7.0"
   },
   "engines": {
-    "node": ">= 18.0.0"
+    "node": ">= 20.0.0",
+    "npm": ">= 10.0.0"
   },
   "nyc": {
     "all": true,


### PR DESCRIPTION
- **build: bump node to 20**
- **docs: bump python to 3.12**

<!-- markdownlint-disable MD041-->
## Description

Bump Node.js from 18 to 20 (LTS) for build. Runtime will be modified directly on AWS once this get's merged and released.

fixes: #391 #392

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
