### PR TITLE
revert: downgrade mkdocs from 1.6.0 to 1.5.3 (#428)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs==1.6.0
+mkdocs==1.5.3
 mkdocs-git-revision-date-plugin==0.3.2
 mkdocs-material==9.5.18


### PR DESCRIPTION
This reverts commit e3a0969848f7c9597d87b3ec9a23a3c8209da826.

<!-- markdownlint-disable MD041-->
## Description

> Describe what you did and why.

**Related issue (if any):** fixes #issue_number_goes_here

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information

> Anything else?
