### PR TITLE
fix: probot 14.0.2 break

### DIFF
--- a/src/app-runner.js
+++ b/src/app-runner.js
@@ -11,7 +11,7 @@ export async function handler (event) {
         logLevel: process.env.LOG_LEVEL || 'info',
     });
 
-    probot.log.debug('loading app');
+    // probot.log.debug('loading app');
     await probot.load(autoMeBot);
     probot.log.debug('app loaded, starting webhook');
 


### PR DESCRIPTION
## Description
<!-- Describe what you did and why. -->
It looks like starting with version 14.0.2, probot's log is only instantiated after loading. We wrote to the log prior to logging, and upgrading to 14.0.2, logs the following:

```txt
2025-11-02T22:36:29.403Z	59cd92d3-98b2-4d5c-997a-130ebf23e93a	ERROR	Invoke Error 	
{
    "errorType": "TypeError",
    "errorMessage": "Cannot read properties of null (reading 'debug')",
    "stack": [
        "TypeError: Cannot read properties of null (reading 'debug')",
        "    at Runtime.handler (file:///var/task/src/app-runner.js:14:16)",
        "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1306:29)"
    ]
}
```

Fixed by not writing to the log prior to loading.

## Checklist

- [x] I have followed this repository's contributing guidelines.
- [x] I will adhere to the project's code of conduct.

## Additional information
<!-- Anything else? -->
