### PR TITLE
chore: use bot identity and SSH signing for commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,17 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup SSH signing
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
+          chmod 600 ~/.ssh/signing_key
+          git config gpg.format ssh
+          git config user.signingkey ~/.ssh/signing_key
+          git config commit.gpgsign true
 
       - name: Configure aws
         uses: aws-actions/configure-aws-credentials@v5


### PR DESCRIPTION
## Summary

- Switch git identity from `github.actor` to `github-actions[bot]` (ID 41898282)
- Add SSH commit signing using `SIGNING_KEY` secret

## Changes

### Identity
```yaml
git config user.name "github-actions[bot]"
git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
```

### SSH Signing
```yaml
- name: Setup SSH signing
  run: |
    mkdir -p ~/.ssh
    echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
    chmod 600 ~/.ssh/signing_key
    git config gpg.format ssh
    git config user.signingkey ~/.ssh/signing_key
    git config commit.gpgsign true
```

## Prerequisites

1. Add public SSH key to GitHub account as signing key
2. Add `SIGNING_KEY` secret to `deployment` environment