### PR TITLE
ci: add bump input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,10 @@ on:
       title:
         description: "Release title"
         required: false
+      bump:
+        description: "Bump type (major/minor/patch/auto)"
+        default: "auto"
+        required: true
 
 jobs:
   release:
@@ -50,6 +54,8 @@ jobs:
       - name: Determine next SemVer
         id: bumper
         uses: tomerfi/version-bumper-action@2.0.5
+        with:
+          bump: '${{ github.event.inputs.bump }}'
 
       - name: Update package with new version
         run: |


### PR DESCRIPTION
## Summary
- Add `bump` input to release workflow for consistency with other projects
- Enables Release Manager tool to specify version bump type

## Test plan
- [x] Verify workflow inputs are correct
- [x] Test release trigger from Release Manager tool