### PR TITLE
fix: await probot.ready() before accessing log in lambda handler

### DIFF
--- a/src/app-runner.js
+++ b/src/app-runner.js
@@ -11,7 +11,8 @@ export async function handler (event) {
         logLevel: process.env.LOG_LEVEL || 'info',
     });
 
-    // probot.log.debug('loading app');
+    await probot.ready();
+    probot.log.debug('loading app');
     await probot.load(autoMeBot);
     probot.log.debug('app loaded, starting webhook');
 


### PR DESCRIPTION
## Summary

- Probot v14 (merged via #687 before the 3.0.9 release) changed `Probot` to use async initialization — the constructor fires `#initialize()` as a fire-and-forget promise, leaving `probot.log` as `null` until it resolves.
- The Lambda handler accessed `probot.log.debug()` synchronously after construction, causing a `TypeError` that broke every release from 3.0.9 (function v91) through 3.0.12 (function v95).
- Adds `await probot.ready()` after constructing the `Probot` instance to wait for async initialization (including logger creation) before accessing any properties.

## Test plan

- [x] Deploy to Lambda and verify the handler no longer throws on `probot.log.debug`
- [x] Confirm webhook events are processed successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application initialization reliability by ensuring the bot instance is fully ready before loading modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->