### PR TITLE
fix: use octokit.rest namespace for all GitHub API calls

### DIFF
--- a/src/handlers/pr-auto-approve.js
+++ b/src/handlers/pr-auto-approve.js
@@ -22,7 +22,7 @@ async function run(context, config, startedAt) {
     context.log.info(`${running_handler} started`)
 
     // create the initial check run and mark it as in_progress
-    let checkRun = await context.octokit.checks.create(context.repo({
+    let checkRun = await context.octokit.rest.checks.create(context.repo({
         head_sha: context.payload.pull_request.head.sha,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,
@@ -47,7 +47,7 @@ async function run(context, config, startedAt) {
                 context.payload.sender.login.replace('[bot]', '').toLowerCase()))
         ) {
             // send approve request
-            await context.octokit.pulls.createReview(context.pullRequest({event: 'APPROVE'}))
+            await context.octokit.rest.pulls.createReview(context.pullRequest({event: 'APPROVE'}))
                 .then(response => {
                     if (response.status === 200) {
                         report.conclusion = 'success';
@@ -75,7 +75,7 @@ async function run(context, config, startedAt) {
     context.log.debug(`${running_handler} finalizing`);
 
     // update check run and mark it as completed
-    await context.octokit.checks.update(context.repo({
+    await context.octokit.rest.checks.update(context.repo({
         check_run_id: checkRun.data.id,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,

--- a/src/handlers/pr-conventional-commits.js
+++ b/src/handlers/pr-conventional-commits.js
@@ -27,7 +27,7 @@ async function run(context, config, startedAt) {
     context.log.info(`${running_handler} started`)
 
     // create the initial check run and mark it as in_progress
-    let checkRun = await context.octokit.checks.create(context.repo({
+    let checkRun = await context.octokit.rest.checks.create(context.repo({
         head_sha: context.payload.pull_request.head.sha,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,
@@ -44,7 +44,7 @@ async function run(context, config, startedAt) {
     };
     // get the commits associated with the PR
     let commitObjs = [];
-    await context.octokit.rest.pulls.listCommits(context.pullRequest()) // TODO: do we need "rest" here?
+    await context.octokit.rest.pulls.listCommits(context.pullRequest())
         .then(response => {
             if (response.status === 200) {
                 commitObjs = response.data;
@@ -104,7 +104,7 @@ async function run(context, config, startedAt) {
     context.log.debug(`${running_handler} finalizing`);
 
     // update check run and mark it as completed
-    await context.octokit.checks.update(context.repo({
+    await context.octokit.rest.checks.update(context.repo({
         check_run_id: checkRun.data.id,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,

--- a/src/handlers/pr-conventional-title.js
+++ b/src/handlers/pr-conventional-title.js
@@ -27,7 +27,7 @@ async function run(context, config, startedAt) {
     context.log.info(`${running_handler} started`)
 
     // create the initial check run and mark it as in_progress
-    let checkRun = await context.octokit.checks.create(context.repo({
+    let checkRun = await context.octokit.rest.checks.create(context.repo({
         head_sha: context.payload.pull_request.head.sha,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,
@@ -60,7 +60,7 @@ async function run(context, config, startedAt) {
     context.log.debug(`${running_handler} finalizing`);
 
     // update check run and mark it as completed
-    await context.octokit.checks.update(context.repo({
+    await context.octokit.rest.checks.update(context.repo({
         check_run_id: checkRun.data.id,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,

--- a/src/handlers/pr-signed-commits.js
+++ b/src/handlers/pr-signed-commits.js
@@ -28,7 +28,7 @@ async function run(context, config, startedAt) {
     context.log.info(`${running_handler} started`)
 
     // create the initial check run and mark it as in_progress
-    let checkRun = await context.octokit.checks.create(context.repo({
+    let checkRun = await context.octokit.rest.checks.create(context.repo({
         head_sha: context.payload.pull_request.head.sha,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,
@@ -45,7 +45,7 @@ async function run(context, config, startedAt) {
     };
     // grab all commits related the pr
     let allCommits = [];
-    await context.octokit.rest.pulls.listCommits(context.pullRequest()) // TODO: do we need "rest" here?
+    await context.octokit.rest.pulls.listCommits(context.pullRequest())
         .then(response => {
             if (response.status === 200) {
                 allCommits = response.data;
@@ -81,7 +81,7 @@ async function run(context, config, startedAt) {
     context.log.debug(`${running_handler} finalizing`);
 
     // update check run and mark it as completed
-    await context.octokit.checks.update(context.repo({
+    await context.octokit.rest.checks.update(context.repo({
         check_run_id: checkRun.data.id,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,

--- a/src/handlers/pr-tasks-list.js
+++ b/src/handlers/pr-tasks-list.js
@@ -25,7 +25,7 @@ async function run(context, _config, startedAt) {
     context.log.info(`${running_handler} started`)
 
     // create the initial check run and mark it as in_progress
-    let checkRun = await context.octokit.checks.create(context.repo({
+    let checkRun = await context.octokit.rest.checks.create(context.repo({
         head_sha: context.payload.pull_request.head.sha,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,
@@ -70,7 +70,7 @@ async function run(context, _config, startedAt) {
     context.log.debug(`${running_handler} finalizing`);
 
     // update check run and mark it as completed
-    await context.octokit.checks.update(context.repo({
+    await context.octokit.rest.checks.update(context.repo({
         check_run_id: checkRun.data.id,
         name: CHECK_NAME,
         details_url: BOT_CHECK_URL,

--- a/tests/handlers/pr-auto-approve.test.js
+++ b/tests/handlers/pr-auto-approve.test.js
@@ -79,12 +79,14 @@ suite('Testing the pr-auto-approve handler', () => {
             // create a fake context for invoking the application with)
             fakeContext = Object.freeze({
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
-                    },
-                    pulls: {
-                        createReview: createReviewStub
+                    rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        },
+                        pulls: {
+                            createReview: createReviewStub
+                        }
                     }
                 },
                 repo: repoFuncStub,

--- a/tests/handlers/pr-conventional-commits.test.js
+++ b/tests/handlers/pr-conventional-commits.test.js
@@ -89,11 +89,11 @@ suite('Testing the pr-conventional-commits handler', () => {
                     }
                 },
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
-                    },
                     rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        },
                         pulls: {
                             listCommits: listCommitsStub
                         }

--- a/tests/handlers/pr-conventional-title.test.js
+++ b/tests/handlers/pr-conventional-title.test.js
@@ -74,9 +74,11 @@ suite('Testing the pr-conventional-title handler', () => {
             // create a fake context for invoking the application with)
             fakeContext = Object.freeze({
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
+                    rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        }
                     }
                 },
                 repo: repoFuncStub,

--- a/tests/handlers/pr-lifecycle-labels.test.js
+++ b/tests/handlers/pr-lifecycle-labels.test.js
@@ -114,20 +114,22 @@ suite('Testing the pr-lifecycle-labels', () => {
                     }
                 },
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
-                    },
-                    issues: {
-                        getLabel: getLabelStub,
-                        addLabels: addLabelsStub,
-                        removeLabel: removeLabelStub
-                    },
-                    pulls: {
-                        listReviews: listReviewStub
-                    },
-                    repos: {
-                        getBranchProtection: branchProtectFuncStub
+                    rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        },
+                        issues: {
+                            getLabel: getLabelStub,
+                            addLabels: addLabelsStub,
+                            removeLabel: removeLabelStub
+                        },
+                        pulls: {
+                            listReviews: listReviewStub
+                        },
+                        repos: {
+                            getBranchProtection: branchProtectFuncStub
+                        }
                     }
                 },
                 repo: repoFuncStub,

--- a/tests/handlers/pr-signed-commits.test.js
+++ b/tests/handlers/pr-signed-commits.test.js
@@ -169,11 +169,11 @@ suite('Testing the pr-signed-commits handler', () => {
                     }
                 },
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
-                    },
                     rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        },
                         pulls: {
                             listCommits: listCommitsStub
                         }

--- a/tests/handlers/pr-tasks-list.test.js
+++ b/tests/handlers/pr-tasks-list.test.js
@@ -80,10 +80,12 @@ suite('Testing the pr-tasks-list handler', () => {
                     }
                 },
                 octokit: {
-                    checks: {
-                        create: createCheckStub,
-                        update: updateCheckStub
-                    },
+                    rest: {
+                        checks: {
+                            create: createCheckStub,
+                            update: updateCheckStub
+                        },
+                    }
                 },
                 repo: repoFuncStub,
                 log: {


### PR DESCRIPTION
## Summary

- Probot v14's `ProbotOctokit` uses `restEndpointMethods` (not `legacyRestEndpointMethods`), which only exposes API methods under `octokit.rest.*`. The top-level aliases (`octokit.checks`, `octokit.pulls`, etc.) no longer exist.
- All handler API calls (`checks.create`, `checks.update`, `pulls.createReview`, `pulls.listReviews`, `issues.addLabels`, `issues.getLabel`, `issues.removeLabel`, `repos.getBranchProtection`) now use the `octokit.rest.*` namespace.
- The errors were silently swallowed by `Promise.allSettled` in the handlers controller, causing check runs to never be created — no errors logged, no checks posted.
- Removed stale TODO comments from `pr-conventional-commits.js` and `pr-signed-commits.js` that already had the correct `rest.pulls.listCommits` path.
- Updated all test stubs to match the new `octokit.rest.*` structure.

## Test plan

- [x] All 100 existing tests pass
- [x] Verified root cause by tracing through `@octokit/plugin-rest-endpoint-methods` source — `restEndpointMethods` returns `{ rest: api }` vs `legacyRestEndpointMethods` returns `{ ...api, rest: api }`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal API integration to use the latest interface structure across multiple handlers and corresponding tests. No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->