### PR TITLE
fix: replace os.EOL with hardcoded newline for cross-platform compatibility

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,8 +8,11 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
-    name: Lint and test project
+    runs-on: ${{ matrix.os }}
+    name: Lint and test project (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6
@@ -30,6 +33,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/src/handlers/pr-conventional-commits.js
+++ b/src/handlers/pr-conventional-commits.js
@@ -1,6 +1,6 @@
 import lint from '@commitlint/lint'
 import load from '@commitlint/load'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 /* example configuration (for reference):
 rules:

--- a/src/handlers/pr-conventional-title.js
+++ b/src/handlers/pr-conventional-title.js
@@ -1,6 +1,6 @@
 import lint from '@commitlint/lint'
 import load from '@commitlint/load'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 /* example configuration (for reference):
 rules:

--- a/src/handlers/pr-signed-commits.js
+++ b/src/handlers/pr-signed-commits.js
@@ -1,4 +1,4 @@
-import { EOL } from 'node:os'
+const EOL = '\n'
 import validator from 'validator';
 
 /* example configuration (for reference):

--- a/src/handlers/pr-tasks-list.js
+++ b/src/handlers/pr-tasks-list.js
@@ -1,5 +1,5 @@
 import { marked } from 'marked'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 const BOT_CHECK_URL = 'https://auto-me-bot.figenblat.com';
 const CHECK_NAME = 'Auto-Me-Bot Tasks List';

--- a/tests/handlers/pr-conventional-commits.test.js
+++ b/tests/handlers/pr-conventional-commits.test.js
@@ -2,7 +2,7 @@ import { expect, use as chaiUse  } from 'chai'
 import sinonChai from 'sinon-chai'
 import sinon from 'sinon'
 import { beforeEach } from 'mocha'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 chaiUse(sinonChai)
 

--- a/tests/handlers/pr-conventional-title.test.js
+++ b/tests/handlers/pr-conventional-title.test.js
@@ -2,7 +2,7 @@ import { expect, use as chaiUse  } from 'chai'
 import sinonChai from 'sinon-chai'
 import sinon from 'sinon'
 import { beforeEach } from 'mocha'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 chaiUse(sinonChai)
 

--- a/tests/handlers/pr-signed-commits.test.js
+++ b/tests/handlers/pr-signed-commits.test.js
@@ -2,7 +2,7 @@ import { expect, use as chaiUse  } from 'chai'
 import sinonChai from 'sinon-chai'
 import sinon from 'sinon'
 import { beforeEach } from 'mocha'
-import { EOL } from 'node:os'
+const EOL = '\n'
 import { cloneDeep } from 'lodash-es'
 
 chaiUse(sinonChai)

--- a/tests/handlers/pr-tasks-list.test.js
+++ b/tests/handlers/pr-tasks-list.test.js
@@ -2,7 +2,7 @@ import { expect, use as chaiUse  } from 'chai'
 import sinonChai from 'sinon-chai'
 import sinon from 'sinon'
 import { beforeEach } from 'mocha'
-import { EOL } from 'node:os'
+const EOL = '\n'
 
 chaiUse(sinonChai)
 


### PR DESCRIPTION
## Summary

- Replace `import { EOL } from 'node:os'` with `const EOL = '\n'` in all handler source files and their tests
- Add `windows-latest` to the PR CI matrix to verify tests pass on Windows
- Codecov upload is scoped to Ubuntu only to avoid duplicate reports

## Root Cause

`os.EOL` returns `\r\n` on Windows but `\n` on Linux/Mac. Third-party libraries (`marked`, `@commitlint/lint`) normalize line endings to `\n` internally, causing mismatches when the handler code joins output with `os.EOL` (`\r\n`) on Windows. Since the bot runs on AWS Lambda (Linux) and outputs GitHub Markdown, `\n` is the correct line ending universally.

## Test plan

- [x] All 102 tests pass locally on macOS
- [x] CI passes on `ubuntu-latest`
- [x] CI passes on `windows-latest` (new)

Closes #54
