### PR TITLE
ci: security hardening for GitHub Actions workflows

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,8 +34,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy to GH Pages
         run: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,6 +5,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: write # checkout, deploy
+
 jobs:
   deploy-pages:
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,19 +12,19 @@ jobs:
     name: Build documentation site and deploy to GH-Pages
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d4688 # v6
         with:
           python-version: "3.13"
 
       - name: Cache pip repository
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: npm
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref }}${{ github.event.number }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # checkout, lint
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,13 +23,13 @@ jobs:
     name: Build, publish, release, and announce
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Install node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: npm
@@ -49,14 +49,14 @@ jobs:
           git config commit.gpgsign true
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Determine next SemVer
         id: bumper
-        uses: tomerfi/version-bumper-action@2.0.7
+        uses: tomerfi/version-bumper-action@6892021917fa099d2986fcbf3acc584659af193a # 2.0.7
         with:
           bump: '${{ github.event.inputs.bump }}'
 
@@ -93,7 +93,7 @@ jobs:
 
       - name: Create a release name
         id: release_name
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           script: |
             var retval = '${{ steps.bumper.outputs.next }}'
@@ -104,7 +104,7 @@ jobs:
 
       - name: Create a release
         id: gh_release
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         with:
           github-token: ${{ secrets.RELEASE_PAT }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,11 +41,11 @@ jobs:
 
       - name: Setup SSH signing
         run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.SIGNING_KEY }}" > ~/.ssh/signing_key
-          chmod 600 ~/.ssh/signing_key
+          KEY_PATH=$RUNNER_TEMP/signing_key
+          echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
+          chmod 600 "$KEY_PATH"
           git config gpg.format ssh
-          git config user.signingkey ~/.ssh/signing_key
+          git config user.signingkey "$KEY_PATH"
           git config commit.gpgsign true
 
       - name: Authenticate to GCP

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,4 +129,6 @@ jobs:
   smoke-test:
     needs: release
     uses: ./.github/workflows/smoke-test.yml
-    secrets: inherit
+    secrets:
+      FUNCTION_URL: ${{ secrets.FUNCTION_URL }}
+      WEBHOOK_SECRET: ${{ secrets.WEBHOOK_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  id-token: write
+  contents: write # git push, release creation
+  id-token: write # GCP WIF authentication
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,10 @@ on:
         default: "auto"
         required: true
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -4,6 +4,11 @@ name: Smoke Test
 on:
   workflow_dispatch:
   workflow_call:
+    secrets:
+      FUNCTION_URL:
+        required: true
+      WEBHOOK_SECRET:
+        required: true
 
 permissions:
   contents: read # smoke test

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -12,10 +12,10 @@ jobs:
     name: Smoke test deployed function
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
 

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -5,6 +5,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read # smoke test
+
 jobs:
   smoke-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -14,21 +14,21 @@ jobs:
     name: Stage the project
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install node 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22'
           cache: npm
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d4688 # v6
         with:
           python-version: "3.13"
 
       - name: Cache pip repository
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
@@ -49,7 +49,7 @@ jobs:
         run: npm test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: stage-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stage:
     runs-on: ubuntu-latest

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -11,6 +11,9 @@ concurrency:
   group: stage-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # checkout, build
+
 jobs:
   stage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions to full SHA digests with version comments — prevents tag manipulation attacks
- Move SSH signing key to `$RUNNER_TEMP` — prevents persisting keys on the runner
- Replace `secrets: inherit` with explicit secret list — limits blast radius of child workflow
- Add minimal permissions blocks to all workflow files — enforce least-privilege
- Use `github-actions[bot]` identity for git config — prevents commit authorship leaking to fork contributors
- Add concurrency blocks — prevent parallel run conflicts
- Add descriptive comments to all permissions blocks for maintainability

## Commits
| Commit | Description |
|---|---|
| `92b1614` | ci: pin all GitHub Actions to full SHA digests with version comments |
| `e29613a` | security: move SSH signing key to runner temp |
| `7a253ba` | ci: replace secrets inherit with explicit secret list |
| `6f2faea` | ci: use bot identity for git config instead of github.actor |
| `efb4c4f` | ci: add concurrency blocks to prevent parallel workflow runs |
| `448e31e` | ci: add permissions blocks with descriptions |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD security by tightening workflow permissions and pinning action versions.
  * Added concurrency controls to reduce redundant runs and speed up pipeline feedback.
  * Made smoke-test invocation require and pass explicit secrets.
  * Standardized automated commit identity for workflow-generated commits.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TomerFi/auto-me-bot/pull/886)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->