### PR TITLE
fix: fix release workflow npm ci failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: deployment
-    name: Build, publish, release, and announce
+    name: Build, publish, and release
     steps:
       - name: Checkout sources
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -75,7 +75,7 @@ jobs:
           npm version ${{ steps.bumper.outputs.next }} --no-git-tag-version
 
       - name: Install project modules
-        run: npm ci --production
+        run: npm ci --omit=dev --ignore-scripts
 
       - name: Deploy to Cloud Functions
         run: >


### PR DESCRIPTION
## Problem

The release workflow fails at the "Install project modules" step with:

```
sh: 1: husky: not found
npm error command failed
```

## Root Cause

`npm ci --production` is a deprecated alias for `npm ci --omit=dev`. It installs only production dependencies (skipping `husky` which is a dev dependency), but still runs lifecycle scripts including the `prepare` hook (`husky`). Since `husky` isn't installed, the script crashes.

## Fix

Replace `npm ci --production` with `npm ci --omit=dev --ignore-scripts`:

- **`--omit=dev`** — explicit, non-deprecated way to skip dev dependencies
- **`--ignore-scripts`** — skip the `prepare` script since `husky` isn't needed for a Cloud Function deployment

This matches the approach used in other CI workflows in the project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to install only production dependencies while skipping install scripts.
  * Clarified the release job name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->