### PR TITLE
ci: husky should run lint-stage from node modules

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -16,4 +16,4 @@ if ! npm run link-ai-files -- --ci; then
   exit 1
 fi
 
-npx lint-staged
+npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "prettier:fix": "echo \"prettier --write .\"",
     "ec": "ec",
     "link-ai-files": "aicfg link agents --to claude-code",
+    "lint-staged": "lint-staged",
     "prepare": "husky || true"
   },
   "lint-staged": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit checks by running the project’s configured linting script directly.
  * Standardized how staged-file validation is invoked during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->