### PR TITLE
ci: removed signing key logic from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,15 +49,6 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Setup SSH signing
-        run: |
-          KEY_PATH=$RUNNER_TEMP/signing_key
-          echo "${{ secrets.SIGNING_KEY }}" > "$KEY_PATH"
-          chmod 600 "$KEY_PATH"
-          git config gpg.format ssh
-          git config user.signingkey "$KEY_PATH"
-          git config commit.gpgsign true
-
       - name: Authenticate to GCP
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to remove SSH-based commit and tag signing configuration.
  * Release commits and tags will proceed without signing configured by this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->